### PR TITLE
Ensure optional members of AppInfoLocalization.Attributes are marked optional

### DIFF
--- a/asconnect/models/app_info.py
+++ b/asconnect/models/app_info.py
@@ -18,9 +18,9 @@ class AppInfoLocalization(Resource):
     class Attributes:
         """Represents app info localization attributes."""
 
-        locale: str
-        name: str
-        privacy_policy_text: str
+        locale: Optional[str]
+        name: Optional[str]
+        privacy_policy_text: Optional[str]
         privacy_policy_url: Optional[str]
         subtitle: Optional[str]
 


### PR DESCRIPTION
This change marks all of the properties in `AppInfoLocalization.Attributes` as optional in accordance with Apple's API documentation here: https://developer.apple.com/documentation/appstoreconnectapi/appinfolocalization/attributes

This should address issue #3.