### PR TITLE
Enable altool logging

### DIFF
--- a/asconnect/altool.py
+++ b/asconnect/altool.py
@@ -73,6 +73,7 @@ def upload(
         key_id,
         "--apiIssuer",
         issuer_id,
+        "--verbose"
     ]
 
     log.info(


### PR DESCRIPTION
Request to enable altool logging for collecting info and send Testflight fail log to Apple team.