### PR TITLE
Make some attributes of AppStoreVersionLocalization optional

### DIFF
--- a/asconnect/models/app_store_version_localizations.py
+++ b/asconnect/models/app_store_version_localizations.py
@@ -18,12 +18,12 @@ class AppStoreVersionLocalization(Resource):
     class Attributes(BaseAttributes):
         """Attributes."""
 
-        description: str
-        keywords: str
+        description: Optional[str]
+        keywords: Optional[str]
         locale: str
         marketing_url: Optional[str]
         promotional_text: Optional[str]
-        support_url: str
+        support_url: Optional[str]
         whats_new: Optional[str]
 
     identifier: str

--- a/asconnect/version_client.py
+++ b/asconnect/version_client.py
@@ -199,7 +199,7 @@ class VersionClient:
 
         :returns: An AppStoreVersion
         """
-        self.log.info("Getting localizations for version {version_id}...")
+        self.log.info(f"Getting localizations for version {version_id}...")
         url = self.http_client.generate_url(
             f"appStoreVersions/{version_id}/appStoreVersionLocalizations"
         )


### PR DESCRIPTION
Encountered following error when trying to add new language support: 
> [2022-07-15 05:51:11.999] [app_store] [ERROR] Cannot deserialize '<class 'NoneType'>' to '<class 'str'>' for 'typing.List[asconnect.models.app_store_version_localizations.AppStoreVersionLocalization][1].attributes.description'

These attributes could be `None` when a language is newly added.