### PR TITLE
Add support for getting the attached build to a specific App Store version

### DIFF
--- a/asconnect/version_client.py
+++ b/asconnect/version_client.py
@@ -17,6 +17,7 @@ from asconnect.models import (
     AppStoreVersionLocalization,
     AppStoreReviewDetails,
     IdfaDeclaration,
+    Build,
 )
 from asconnect.utilities import next_or_none, update_query_parameters
 
@@ -205,6 +206,19 @@ class VersionClient:
             f"appStoreVersions/{version_id}/appStoreVersionLocalizations"
         )
         yield from self.http_client.get(url=url, data_type=List[AppStoreVersionLocalization])
+
+    def get_attached_build(self, *, version_id: str) -> Optional[Build]:
+        """Get the build that is attached to a specific App Store version.
+
+        :param version_id: The version ID to get the build for
+
+        :returns: A Build
+        """
+        self.log.info(f"Getting build for version {version_id}...")
+        
+        url = self.http_client.generate_url(f"appStoreVersions/{version_id}/build")
+
+        return next_or_none(self.http_client.get(url=url, data_type=Build))
 
     def set_build(self, *, version_id: str, build_id: str) -> None:
         """Set the build for a version

--- a/asconnect/version_client.py
+++ b/asconnect/version_client.py
@@ -215,7 +215,7 @@ class VersionClient:
         :returns: A Build
         """
         self.log.info(f"Getting build for version {version_id}...")
-        
+
         url = self.http_client.generate_url(f"appStoreVersions/{version_id}/build")
 
         return next_or_none(self.http_client.get(url=url, data_type=Build))

--- a/tests/test_asconnect.py
+++ b/tests/test_asconnect.py
@@ -82,6 +82,27 @@ def test_get_apps() -> None:
     print(apps[0])
 
 
+def test_get_attached_build() -> None:
+    """Test get attached build."""
+
+    key_id, key_contents, issuer_id = get_test_data()
+
+    client = asconnect.Client(
+        key_id=key_id,
+        key_contents=key_contents,
+        issuer_id=issuer_id,
+    )
+
+    app = client.app.get_from_bundle_id(APP_ID)
+    assert app is not None
+
+    version = client.version.get_version(app_id=app.identifier, version_string="1.2.3")
+    assert version is not None
+
+    build = client.version.get_attached_build(version_id=version.identifier)
+    assert build is not None
+
+
 def test_get_builds() -> None:
     """Test get apps."""
     key_id, key_contents, issuer_id = get_test_data()


### PR DESCRIPTION
Get the build that is attached to a specific App Store version.

It's a wrapper for this API:
https://developer.apple.com/documentation/appstoreconnectapi/read_the_build_information_of_an_app_store_version