### PR TITLE
Fix AppScreenshot deserialize issue

### DIFF
--- a/asconnect/models/screenshots.py
+++ b/asconnect/models/screenshots.py
@@ -17,12 +17,15 @@ class ScreenshotDisplayType(enum.Enum):
     APP_IPHONE_47 = "APP_IPHONE_47"
     APP_IPHONE_40 = "APP_IPHONE_40"
     APP_IPHONE_35 = "APP_IPHONE_35"
+    APP_IPAD_PRO_6GEN_129 = "APP_IPAD_PRO_6GEN_129"
     APP_IPAD_PRO_3GEN_129 = "APP_IPAD_PRO_3GEN_129"
+    APP_IPAD_PRO_2GEN_129 = "APP_IPAD_PRO_2GEN_129"
     APP_IPAD_PRO_3GEN_11 = "APP_IPAD_PRO_3GEN_11"
     APP_IPAD_PRO_129 = "APP_IPAD_PRO_129"
     APP_IPAD_105 = "APP_IPAD_105"
     APP_IPAD_97 = "APP_IPAD_97"
     APP_DESKTOP = "APP_DESKTOP"
+    APP_WATCH_SERIES_7 = "APP_WATCH_SERIES_7"
     APP_WATCH_SERIES_4 = "APP_WATCH_SERIES_4"
     APP_WATCH_SERIES_3 = "APP_WATCH_SERIES_3"
     APP_APPLE_TV = "APP_APPLE_TV"
@@ -135,7 +138,7 @@ class AppScreenshot(Resource):
         asset_token: str
         asset_type: str
         file_name: str
-        file_size: int
+        file_size: Optional[int]
         image_asset: Optional[ImageAsset]
         source_file_checksum: Optional[str]
         uploaded: Optional[bool]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asconnect"
-version = "2.2.13"
+version = "3.0.0"
 description = "A wrapper around the Apple App Store Connect APIs"
 
 license = "MIT"


### PR DESCRIPTION
- Fix following AppScreenshot deserialize issue:

```[2023-05-26 08:08:39.544] [app_store] [ERROR] Cannot deserialize '<class 'NoneType'>' to '<class 'int'>' for 'List[0].attributes.file_size'```

- Add new display types
- Bump major version, which should have been done since we last upgrade Python version