### PR TITLE
Make brazil_age_rating in AppInfo optional

### DIFF
--- a/asconnect/models/app_info.py
+++ b/asconnect/models/app_info.py
@@ -71,7 +71,7 @@ class AppInfo(Resource):
 
         app_store_age_rating: AppStoreAgeRating
         app_store_state: AppStoreVersionState
-        brazil_age_rating: BrazilAgeRating
+        brazil_age_rating: Optional[BrazilAgeRating]
         kids_age_band: Optional[KidsAgeBand]
 
     identifier: str


### PR DESCRIPTION
Make brazil_age_rating in AppInfo optional to fix the issue: _**Cannot deserialize '<class 'NoneType'>' to '<enum 'BrazilAgeRating'>' for 'List[0].attributes.brazil_age_rating'**_