### PR TITLE
Use review submission API

### DIFF
--- a/asconnect/models/app_store.py
+++ b/asconnect/models/app_store.py
@@ -14,6 +14,7 @@ class Platform(enum.Enum):
     IOS = "IOS"
     MACOS = "MAC_OS"
     TVOS = "TV_OS"
+    VISIONOS = "VISION_OS"
 
 
 class ReleaseType(enum.Enum):

--- a/asconnect/version_client.py
+++ b/asconnect/version_client.py
@@ -447,6 +447,7 @@ class VersionClient:
         """Submit the version for review
 
         :param version_id: The ID of the version to submit for review
+        :param platform: The platform the app is for
         :param attempt: The attempt this is
         :param max_attempts: The number of attempts allowed
         """

--- a/asconnect/version_client.py
+++ b/asconnect/version_client.py
@@ -440,6 +440,7 @@ class VersionClient:
         self,
         *,
         version_id: str,
+        platform: Platform = Platform.IOS,
         attempt: int = 1,
         max_attempts: int = 3,
     ) -> None:
@@ -450,17 +451,20 @@ class VersionClient:
         :param max_attempts: The number of attempts allowed
         """
 
-        self.log.info(f"Submitting version for review {version_id}")
+        self.log.info(f"Submitting version for review {version_id}, platform: {platform}")
 
         try:
             self.http_client.post(
-                endpoint="appStoreVersionSubmissions",
+                endpoint="reviewSubmissions",
                 data={
                     "data": {
-                        "type": "appStoreVersionSubmissions",
+                        "type": "reviewSubmissions",
+                        "attributes": {
+                            "platform": platform.value
+                        },
                         "relationships": {
-                            "appStoreVersion": {
-                                "data": {"type": "appStoreVersions", "id": version_id}
+                            "app": {
+                                "data": {"type": "apps", "id": version_id}
                             }
                         },
                     }


### PR DESCRIPTION
[appStoreVersionSubmissions](https://developer.apple.com/documentation/appstoreconnectapi/create_an_app_store_version_submission) had been deprecated, this PR changes to use the new API [reviewSubmissions](https://developer.apple.com/documentation/appstoreconnectapi/create_a_review_submission).