### PR TITLE
Fix app not submitted for review

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asconnect"
-version = "3.0.8"
+version = "4.0.0"
 description = "A wrapper around the Apple App Store Connect APIs"
 
 license = "MIT"


### PR DESCRIPTION
Fix error when calling `reviewSubmissions` API:
```txt
Response: status code 409, content: {
  "errors" : [ {
    "id" : "064e717c-abd8-435e-8858-2a2403e3155e",
    "status" : "409",
    "code" : "ENTITY_ERROR.RELATIONSHIP.INVALID",
    "title" : "Relationship is invalid",
    "detail" : "app with id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx cannot be found",
    "source" : {
      "pointer" : "/data/relationships/app"
    }
  } ]
}
```

Also bumping the major version as we are making breaking changes to the API.