### PR TITLE
Fix fail to deserialize ReviewSubmission

### DIFF
--- a/asconnect/models/submission.py
+++ b/asconnect/models/submission.py
@@ -9,13 +9,11 @@ from asconnect.models.common import BaseAttributes, Resource, Links
 class ReviewSubmission(Resource):
     """Represents an app store review details."""
 
-    @deserialize.key("submitted_date", "submittedDate")
     class Attributes(BaseAttributes):
         """Attributes."""
 
         platform: str
         state: str
-        submitted_date: str
 
     identifier: str
     attributes: Attributes


### PR DESCRIPTION
Fix error when calling review submission API:
```txt
[ERROR] Cannot deserialize '<class 'NoneType'>' to '<class 'str'>' for 'ReviewSubmission.attributes.submitted_date'
```

The `submitted_date` changed to optional, resulting in deserialization failure. Since this is not used, this PR directly deletes this attribute.