### PR TITLE
Fix upload screenshot failure

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/asconnect/httpclient.py
+++ b/asconnect/httpclient.py
@@ -415,6 +415,7 @@ class HttpClient:
         url: str,
         additional_headers: Dict[str, str],
         data: bytes,
+        use_auth_header: bool = True,
         log_response: bool = False,
     ) -> requests.Response:
         """Perform a PUT to the url specified
@@ -422,16 +423,20 @@ class HttpClient:
         :param str url: The full URL to perform the PUT on
         :param Dict[str,str] additional_headers: The additional headers to add
         :param bytes data: The raw data to upload
+        :param use_auth_header: A flag indicates whether an auth header will be included in the request
         :param log_response: A flag indicates whether to log the response
 
         :returns: The raw response
         """
         token = self.generate_token()
 
-        headers = {
-            **{"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
-            **additional_headers,
-        }
+        if use_auth_header:
+            headers = {
+                **{"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+                **additional_headers,
+            }
+        else:
+            headers = additional_headers
 
         raw_response = requests.put(url=url, data=data, headers=headers)
 

--- a/asconnect/httpclient.py
+++ b/asconnect/httpclient.py
@@ -430,13 +430,13 @@ class HttpClient:
         """
         token = self.generate_token()
 
-        if use_auth_header:
-            headers = {
-                **{"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
-                **additional_headers,
-            }
-        else:
-            headers = additional_headers
+        headers = additional_headers
+
+        if use_auth_header and ("Authorization" not in headers):
+            headers["Authorization"] = f"Bearer {token}"
+
+        if "Content-Type" not in headers:
+            headers["Content-Type"] = "application/json"
 
         raw_response = requests.put(url=url, data=data, headers=headers)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
     'Environment :: MacOS X',
     'Intended Audience :: Developers',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
Fix HTTP 400 error when uploading screenshot:
```
<?xml version="1.0" encoding="UTF-8" standalone="no"?><Error><Code>400</Code><Message>Invalid request: </Message><RequestId>cb58f765-9685-43d0-9f59-00000000</RequestId></Error>
```
The `Authorization` header is no needed when uploading screenshots.

Also drops Python 3.8 to align with poetry compatibility.