### PR TITLE
Fix check against app identifier

### DIFF
--- a/asconnect/build_client.py
+++ b/asconnect/build_client.py
@@ -94,16 +94,16 @@ class BuildClient:
 
         return next_or_none(self.http_client.get(url=url, data_type=Build))
 
-    def get_from_build_number(self, bundle_id: str, build_number: str) -> Build | None:
+    def get_from_build_number(self, app_id: str, build_number: str) -> Build | None:
         """Get a build from its build number.
 
-        :param bundle_id: The bundle ID of the app
+        :param app_id: The ID of the app
         :param build_number: The build number for the build to get
 
         :returns: The build if found, None otherwise
         """
 
-        self.log.info(f"Getting build from build number {build_number} for bundle {bundle_id}")
+        self.log.info(f"Getting build from build number {build_number} for app {app_id}")
 
         for build in self.get_builds(build_number=build_number):
             self.log.debug(f"Checking build {build}")
@@ -117,17 +117,17 @@ class BuildClient:
             if not app:
                 break
 
-            if app.identifier == bundle_id:
+            if app.identifier == app_id:
                 return build
 
         return None
 
     def wait_for_build_to_process(
-        self, bundle_id: str, build_number: str, wait_time: int = 30
+        self, app_id: str, build_number: str, wait_time: int = 30
     ) -> Build:
         """Wait for a build to finish processing.
 
-        :param bundle_id: The ID of the app
+        :param app_id: The ID of the app
         :param build_number: The build number for the build to wait for
         :param wait_time: The time to wait between checks for processing completion in seconds
 
@@ -137,7 +137,7 @@ class BuildClient:
 
         while True:
             self.log.info("Waiting for build to appear...")
-            build = self.get_from_build_number(bundle_id, build_number)
+            build = self.get_from_build_number(app_id, build_number)
             if build is not None:
                 break
             time.sleep(wait_time)

--- a/asconnect/build_client.py
+++ b/asconnect/build_client.py
@@ -117,7 +117,7 @@ class BuildClient:
             if not app:
                 break
 
-            if app.bundle_id == bundle_id:
+            if app.identifier == bundle_id:
                 return build
 
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asconnect"
-version = "6.0.0"
+version = "6.0.1"
 description = "A wrapper around the Apple App Store Connect APIs"
 
 license = "MIT"

--- a/tests/test_asconnect.py
+++ b/tests/test_asconnect.py
@@ -249,7 +249,7 @@ def test_get_build_localization_details() -> None:
         issuer_id=issuer_id,
     )
 
-    build = client.build.get_from_build_number(build_number="", bundle_id=APP_ID)
+    build = client.build.get_from_build_number(build_number="", app_id=APP_ID)
 
     assert build is not None
 
@@ -266,7 +266,7 @@ def test_set_whats_new() -> None:
         issuer_id=issuer_id,
     )
 
-    build = client.build.get_from_build_number(build_number="", bundle_id=APP_ID)
+    build = client.build.get_from_build_number(build_number="", app_id=APP_ID)
 
     assert build is not None
 
@@ -286,7 +286,7 @@ def test_get_build_beta_detail() -> None:
         issuer_id=issuer_id,
     )
 
-    build = client.build.get_from_build_number(build_number="", bundle_id=APP_ID)
+    build = client.build.get_from_build_number(build_number="", app_id=APP_ID)
 
     assert build is not None
 
@@ -332,7 +332,7 @@ def test_set_beta_groups_detail() -> None:
 
     assert app is not None
 
-    build = client.build.get_from_build_number(build_number="", bundle_id=APP_ID)
+    build = client.build.get_from_build_number(build_number="", app_id=APP_ID)
 
     assert build is not None
 
@@ -355,7 +355,7 @@ def test_beta_review_submission() -> None:
         issuer_id=issuer_id,
     )
 
-    build = client.build.get_from_build_number(build_number="", bundle_id=APP_ID)
+    build = client.build.get_from_build_number(build_number="", app_id=APP_ID)
 
     assert build is not None
 


### PR DESCRIPTION
We were checking `bundle_id` which is `com.microsoft.Whatever` but should be checking `identifier` which is a numeric value that Apple generates.