### PR TITLE
Fix release action version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
 
     - name: Create GitHub Release
       id: create_release
-      uses: comnoco/create-release@v2
+      uses: comnoco/create-release@v2.0.5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:


### PR DESCRIPTION
Despite the documentation saying to use `@v2`, that doesn't work. Trying now with the latest available version. 