### PR TITLE
Fix top-level Platform enum to use App Store Connect API values

### DIFF
--- a/asconnect/__init__.py
+++ b/asconnect/__init__.py
@@ -8,5 +8,4 @@
 from asconnect.client import Client
 from asconnect.models import App
 from asconnect.models import Build
-
-from asconnect.altool import Platform
+from asconnect.models import Platform

--- a/asconnect/altool.py
+++ b/asconnect/altool.py
@@ -1,17 +1,20 @@
 """Wrapper for altool."""
 
-import enum
 import logging
 import subprocess
 import time
 
+from asconnect.models import Platform
 
-class Platform(enum.Enum):
-    """The platforms that altool supports."""
-
-    IOS = "ios"
-    MACOS = "osx"
-    TVOS = "appletvos"
+# altool's `-t` flag uses platform identifiers that differ from the App Store
+# Connect REST API values on `models.Platform`. Keep the API-facing enum as the
+# single source of truth and translate here at the subprocess boundary.
+_ALTOOL_PLATFORM_VALUES: dict[Platform, str] = {
+    Platform.IOS: "ios",
+    Platform.MACOS: "osx",
+    Platform.TVOS: "appletvos",
+    Platform.VISIONOS: "visionos",
+}
 
 
 def _check_should_restart(line: str) -> bool:
@@ -61,6 +64,11 @@ def upload(
     else:
         log = logging.getLogger(__name__)
 
+    try:
+        altool_platform = _ALTOOL_PLATFORM_VALUES[platform]
+    except KeyError as ex:
+        raise ValueError(f"altool does not support platform {platform}") from ex
+
     command = [
         "xcrun",
         "altool",
@@ -68,7 +76,7 @@ def upload(
         "-f",
         ipa_path,
         "-t",
-        platform.value,
+        altool_platform,
         "--api-key",
         key_id,
         "--api-issuer",

--- a/asconnect/altool.py
+++ b/asconnect/altool.py
@@ -56,6 +56,7 @@ def upload(
     :param attempt: The attempt this is
     :param max_attempts: The number of attempts allowed
 
+    :raises ValueError: If altool does not support the given platform
     :raises CalledProcessError: If something goes wrong during upload
     """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asconnect"
-version = "7.1.1"
+version = "7.2.0"
 description = "A wrapper around the Apple App Store Connect APIs"
 
 license = "MIT"

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -31,6 +31,9 @@ def test_platform_values_match_app_store_connect_api() -> None:
 
 def test_altool_maps_platform_to_cli_values() -> None:
     """altool's `-t` flag uses different identifiers than the REST API."""
+    # This test deliberately asserts the contents of the module-private lookup
+    # table that maps the API platform enum to altool's CLI flag values.
+    # pylint: disable=protected-access
     assert altool._ALTOOL_PLATFORM_VALUES[ModelsPlatform.IOS] == "ios"
     assert altool._ALTOOL_PLATFORM_VALUES[ModelsPlatform.MACOS] == "osx"
     assert altool._ALTOOL_PLATFORM_VALUES[ModelsPlatform.TVOS] == "appletvos"

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1,0 +1,37 @@
+"""Tests for the Platform enum exposed at the package top level.
+
+The top-level `asconnect.Platform` must resolve to the App Store Connect REST
+API enum (`asconnect.models.Platform`). Apple rejects the legacy altool-style
+lowercase values (e.g. `"ios"`) on endpoints such as `reviewSubmissions` with:
+
+    [409] 'ios' is not a valid value for the attribute 'platform'.
+    Expected one of: 'VISION_OS', 'MAC_OS', 'IOS', 'TV_OS'
+
+If anyone re-introduces a duplicate `Platform` enum whose values match altool's
+CLI flags, these assertions catch it before it ships.
+"""
+
+import asconnect
+from asconnect import altool
+from asconnect.models import Platform as ModelsPlatform
+
+
+def test_top_level_platform_is_models_platform() -> None:
+    """`asconnect.Platform` must be the App Store Connect API enum."""
+    assert asconnect.Platform is ModelsPlatform
+
+
+def test_platform_values_match_app_store_connect_api() -> None:
+    """Values must be the uppercase strings the REST API expects."""
+    assert ModelsPlatform.IOS.value == "IOS"
+    assert ModelsPlatform.MACOS.value == "MAC_OS"
+    assert ModelsPlatform.TVOS.value == "TV_OS"
+    assert ModelsPlatform.VISIONOS.value == "VISION_OS"
+
+
+def test_altool_maps_platform_to_cli_values() -> None:
+    """altool's `-t` flag uses different identifiers than the REST API."""
+    assert altool._ALTOOL_PLATFORM_VALUES[ModelsPlatform.IOS] == "ios"
+    assert altool._ALTOOL_PLATFORM_VALUES[ModelsPlatform.MACOS] == "osx"
+    assert altool._ALTOOL_PLATFORM_VALUES[ModelsPlatform.TVOS] == "appletvos"
+    assert altool._ALTOOL_PLATFORM_VALUES[ModelsPlatform.VISIONOS] == "visionos"


### PR DESCRIPTION
## Summary

- `asconnect.Platform` was re-exported from `asconnect.altool`, whose enum values match the altool CLI (`IOS = "ios"`, `MACOS = "osx"`, `TVOS = "appletvos"`). The REST API clients (`VersionClient`, `AppClient`) forward `platform.value` straight into request bodies (e.g. `reviewSubmissions`, `appStoreVersions`), so Apple rejects them with `[409] 'ios' is not a valid value for the attribute 'platform'. Expected one of: 'VISION_OS', 'MAC_OS', 'IOS', 'TV_OS'`.
- Re-export `asconnect.models.Platform` (`IOS = "IOS"`, `MACOS = "MAC_OS"`, `TVOS = "TV_OS"`, `VISIONOS = "VISION_OS"`) as the top-level `Platform` so API calls are correct out of the box.
- Delete the duplicate enum in `altool.py`; translate to the altool `-t` flag value at the subprocess boundary via a lookup table. The altool command line is byte-for-byte unchanged.
- Add regression tests asserting `asconnect.Platform is asconnect.models.Platform`, the REST values, and the altool CLI mapping.
- Bump to 7.2.0 since `Platform.IOS.value` changes from `"ios"` to `"IOS"` — observable to any caller reading `.value` directly.

## Background

Discovered via a pipeline failure in the OneDrive iOS `Upload to App Store and Release` pipeline. The `submit_for_review` call at `asconnect/version_client.py:505` sends `{"platform": platform.value}` to Apple's `reviewSubmissions` endpoint, and Apple has tightened validation on that attribute so lowercase `"ios"` is now rejected outright.
