### PR TITLE
Fix CI Python matrix (3.11-3.14) and modernize workflow actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,13 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary

The `lint` workflow matrix tested Python `["3.9", "3.10", "3.11"]`, but the package already declares `python = "^3.11"`. As of Poetry 2.4.1, the **3.9 job fails outright** — Poetry's installer no longer runs under Python 3.9 (`Installing Poetry (2.4.1): An error occurred`) — and 3.9/3.10 were below the project's existing supported floor regardless.

This currently breaks CI on `main` and on every open PR.

## Changes

- **Matrix → `["3.11", "3.12", "3.13", "3.14"]`** — the interpreters allowed by the existing `python = "^3.11"`.
- **`actions/setup-python@v3 → @v5`** and **`actions/checkout@v3 → @v4`** — `@v3` is two majors behind, runs on the deprecated node16 runtime, and won't reliably install 3.13/3.14.

CI-only change — **no version bump** (the `^3.11` requirement already existed; this only aligns CI with it).

## Notes

- This is the only one of the recent failures that belongs on `main` (the other PRs' pylint failures are specific to their own branches and are fixed there).
- After this merges, rebasing #84 and #87 onto `main` replaces their failing 3.9 jobs with the green 3.11–3.14 matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
